### PR TITLE
[4] Addition of some code the stops xhr requests showing in cypress console log

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -19,3 +19,13 @@ import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+// Stop XHR requests being printed out in the console log when running tests
+// This makes for a cleaner console log of what is happening in the tests
+const app = window.top;
+if (!app.document.head.querySelector("[data-hide-command-log-request]")) {
+ const style = app.document.createElement("style");
+ style.innerHTML =".command-name-request, .command-name-xhr { display: none }";
+ style.setAttribute("data-hide-command-log-request", "");
+ app.document.head.appendChild(style); 
+}


### PR DESCRIPTION
## Description
Feature #4 This PR is for the addition of some code that will stop XHR requests from showing in the Cypress console log when running tests, allowing for a more cleaner looking test run.

## Change Log
- Added some code to the `/support/e2e.js` file that stops xhr requests showing

## Steps to test
Checkout to the branch
run `npm run test:e2e` to start up the docker container
run` npx cypress open `to start up Cypress
Choose End to End testing
Run any test
Notice the test runs without showing XHR showing in the console
Comment out the code that has been added as part of this PR
Run the test again
Notice the XHR requests in the console

## Screenshots/Videos
Console log before introduction of code - http://bigbite.im/i/Xgfr3S
Console lof after introduction of code - http://bigbite.im/i/Ui0Pu0

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
