### PR TITLE
[4] new test for users seeing the release notes widget in dashboard

### DIFF
--- a/cypress/e2e/users-see-release-notes-in-dashboard.cy.js
+++ b/cypress/e2e/users-see-release-notes-in-dashboard.cy.js
@@ -1,0 +1,29 @@
+/// <reference types="cypress" />
+
+const userRoles = [
+    'admin',
+    'editor',
+    'subscriber',
+    'contributor',
+    'author',
+];
+
+describe('users can see the release notes widget in the dashboard', () => {
+
+    userRoles.forEach((role) => {
+
+        describe(`${role} access`, () => {
+            beforeEach(() => {
+                cy.switchUser(role);
+                cy.visit('/admin/');
+            })
+
+            it(`should allow ${role} to see the release notes widget`, () => {
+                cy.get('#release_notes_widget').should('be.visible');
+                cy.get('#release_notes_widget').should('contain', 'Whats Changed?');
+                cy.get('.release-note-footer > a').should('contain', 'View All Release Notes');
+            });
+        });
+
+    });
+});

--- a/cypress/seeds/DefaultSeeder.php
+++ b/cypress/seeds/DefaultSeeder.php
@@ -5,5 +5,8 @@ use WP_Cypress\Fixtures;
 
 class DefaultSeeder extends Seeder {
 	public function run() {
+		$this->call([
+			"ReleaseNoteSeeder"
+		]);
 	}
 }


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above - DO NOT USE BRANCH NAMES.
Titles should use Jira ticket references and title where applicable.
Example: [JIRA-0001] Outline additional requested information for Pull Requests.
--->

## Description
Test for #4 - This PR is for a test within the issue that is ran to verify that all users can see the release notes widget in the admin dashboard after release note has been published.

## Change Log
- added test that tests all users can see the release notes widget in the dashboard
- Added a release notes seeder that seeds the database with a number of release notes

## Steps to test
Checkout to the branch
run `npm run test:e2e` to start up the docker container
run `npx cypress open` to start up Cypress
Choose End to End testing
Run `users-see-release-notes-in-dashboard` test

## Screenshots/Videos
Successful run of test - http://bigbite.im/v/eADvOb

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
